### PR TITLE
fixed .RelatedPages to Site.Pages because .RelatedPages was deprecated

### DIFF
--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -2,7 +2,7 @@
   <section>
     <h5>Pour un peu plus de lecture ...</h5>
     <ul>
-      {{ range first 5 .RelatedPages }}
+      {{ range first 5 .Site.Pages }}
       <li>
         <a href="{{ .Permalink }}">{{ .Title }} - {{ .ReadingTime }} Minutes</a>
       </li>


### PR DESCRIPTION
I like your theme. But a below build error has occurred.

> % hugo server -t hugo-theme-crisp                                                                                        (git)-[master]
> ERROR: 2016/01/03 18:57:25 template.go:120: template: theme/partials/related.html:5:23: executing "theme/partials/related.html" at <.RelatedPages>: RelatedPages is not a field of struct type *hugolib.Page in theme/partials/related.html
> ...

http://gohugo.io/templates/variables/

> .Site.Pages Array of all content ordered by Date, newest first. Replaces the now-deprecated .Site.Recent starting v0.13.
